### PR TITLE
Add update listener to group's badge listing

### DIFF
--- a/timApp/static/scripts/tim/gamification/badge/badge-giver.component.ts
+++ b/timApp/static/scripts/tim/gamification/badge/badge-giver.component.ts
@@ -164,6 +164,9 @@ export class BadgeGiverComponent implements OnInit {
                 if (this.selectedUser?.id != undefined) {
                     this.fetchUserBadges(this.selectedUser.id); // Refresh badges
                 }
+                if (this.selectedGroup?.id != undefined) {
+                    this.fetchGroupBadges(this.selectedGroup.id); // Refresh group badges
+                }
             })
         );
     }


### PR DESCRIPTION
Groups badges now update in real time when a new badge gets assigned to whole group