### PR TITLE
update group's badges in viewer without page refreshing

### DIFF
--- a/timApp/static/scripts/tim/gamification/badge/badge-viewer.component.ts
+++ b/timApp/static/scripts/tim/gamification/badge/badge-viewer.component.ts
@@ -122,6 +122,7 @@ export class BadgeViewerComponent implements OnInit {
 
         this.subscription = this.badgeService.updateBadgeList$.subscribe(() => {
             this.getBadges(this.userID);
+            this.getGroupBadges();
         });
     }
 


### PR DESCRIPTION
Fix viewer to update group's badges in real time