### PR TITLE
Fix scrolling bug in badge-viewer

### DIFF
--- a/timApp/static/scripts/tim/gamification/badge/badge-viewer.component.ts
+++ b/timApp/static/scripts/tim/gamification/badge/badge-viewer.component.ts
@@ -118,10 +118,14 @@ export class BadgeViewerComponent implements OnInit {
     }
 
     onScroll(event: WheelEvent) {
-        const targetElement = event.currentTarget as HTMLElement;
-        const scrollAmount = event.deltaY * 0.5;
-        targetElement.scrollLeft += scrollAmount;
-        event.preventDefault();
+        const element = event.currentTarget as HTMLElement;
+        const scrollable = element.scrollWidth > element.clientWidth;
+        if (scrollable) {
+            const targetElement = event.currentTarget as HTMLElement;
+            const scrollAmount = event.deltaY * 0.5;
+            targetElement.scrollLeft += scrollAmount;
+            event.preventDefault();
+        }
     }
 
     ngOnInit() {


### PR DESCRIPTION
Fixed a bug where one could not scroll over badge viewer component without getting stuck when there were too little badges for the scrollbar to appear.