### PR TITLE
Change usernames to real names in badge assignment

### DIFF
--- a/timApp/static/scripts/tim/gamification/badge/badge-giver.component.ts
+++ b/timApp/static/scripts/tim/gamification/badge/badge-giver.component.ts
@@ -66,7 +66,7 @@ import {TimUtilityModule} from "tim/ui/tim-utility.module";
                             (change)="toggleUserSelection(user, $event)"
                         />
                         <span class="option-name" (click)="selectedUser = user; fetchUserBadges(user)" [ngClass]="{'selected-option': selectedUser?.id === user.id}">
-                            {{user.name}}
+                            {{user.real_name}}
                         </span>
                     </div>
                 </div>


### PR DESCRIPTION
Changed badge giver's name listing to use real names instead of user names.