### PR TITLE
Fix scrolling bug in badge withdrawing view

### DIFF
--- a/timApp/static/scripts/tim/gamification/badge/badge-withdraw.component.ts
+++ b/timApp/static/scripts/tim/gamification/badge/badge-withdraw.component.ts
@@ -147,10 +147,14 @@ export class BadgeWithdrawComponent implements OnInit {
     ) {}
 
     onScroll(event: WheelEvent) {
-        const targetElement = event.currentTarget as HTMLElement;
-        const scrollAmount = event.deltaY * 0.5;
-        targetElement.scrollLeft += scrollAmount;
-        event.preventDefault();
+        const element = event.currentTarget as HTMLElement;
+        const scrollable = element.scrollWidth > element.clientWidth;
+        if (scrollable) {
+            const targetElement = event.currentTarget as HTMLElement;
+            const scrollAmount = event.deltaY * 0.5;
+            targetElement.scrollLeft += scrollAmount;
+            event.preventDefault();
+        }
     }
 
     ngOnInit() {


### PR DESCRIPTION
Fixes a bug where one could get stuck on the page in badge withdrawing view when scrolling over user's or group's badges while there was not enough badges to make scrollbar visible.