### PR TITLE
Backend badge testing 7

### DIFF
--- a/timApp/gamification/badge/routes.py
+++ b/timApp/gamification/badge/routes.py
@@ -513,30 +513,6 @@ def get_groups_badges(group_id: int, context_group: str) -> Response:
     return json_response(badges_json)
 
 
-# TODO: Is this an unnecessary route? Can badge_holders-route do the same?
-# TODO: Do access right checks and create tests for that.
-@badges_blueprint.get("/badge_given/<badge_id>")
-def get_badge_given(badge_id: int) -> Response:
-    """
-    Checks if a badge has been given to usergroups.
-    :param badge_id: ID of the badge
-    :return: BadgeGivens in json response format
-    """
-    badge = Badge.get_by_id(badge_id)
-    if not badge:
-        raise NotExist(f'Badge with id "{badge_id}" not found')
-    badge_given = (
-        run_sql(
-            select(BadgeGiven)
-            .filter(BadgeGiven.active)
-            .filter(BadgeGiven.badge_id == badge_id)
-        )
-        .scalars()
-        .all()
-    )
-    return json_response(badge_given)
-
-
 # TODO: Do access right checks and create tests for that.
 @badges_blueprint.get("/badge_holders/<badge_id>")
 def get_badge_holders(badge_id: int) -> Response:

--- a/timApp/gamification/badge/routes.py
+++ b/timApp/gamification/badge/routes.py
@@ -89,7 +89,6 @@ def check_group_member(current_user: User, usergroup: int) -> bool:
         return False
 
 
-# TODO: Not yet in use. If going to use this route, create tests for it and handle errors.
 @badges_blueprint.get("/all_badges_including_inactive")
 def all_badges_including_inactive() -> Response:
     """
@@ -131,6 +130,9 @@ def all_badges_in_context(context_group: str) -> Response:
     if not d:
         raise NotExist(f'User group "{context_group}" not found')
     context_usergroup = UserGroup.get_by_name(context_group)
+    # TODO: Add attribute message=f"Sorry, you don't have permission to use this resource.
+    #       If you are a teacher of context_group, please contact TIM admin."
+    #       and remove corresponding error message generation from frontend.
     verify_teacher_access(d)
     badges = (
         run_sql(
@@ -147,7 +149,6 @@ def all_badges_in_context(context_group: str) -> Response:
     return json_response(badges_json)
 
 
-# TODO: Not yet in use. If going to use this route, create tests for it and handle errors.
 @badges_blueprint.get("/badge/<badge_id>")
 def get_badge(badge_id: int) -> Response:
     """
@@ -184,6 +185,9 @@ def create_badge(
     d = DocEntry.find_by_path(f"groups/{context_group}")  # TODO: Make this unambiguous.
     if not d:
         raise NotExist(f'User group "{context_group}" not found')
+    # TODO: Add attribute message=f"Sorry, you don't have permission to use this resource.
+    #       If you are a teacher of context_group, please contact TIM admin."
+    #       and remove corresponding error message generation from frontend.
     verify_teacher_access(d)
     context_usergroup = UserGroup.get_by_name(context_group)
     badge = Badge(
@@ -246,6 +250,9 @@ def modify_badge(
     )  # TODO: Make this unambiguous.
     if not d:
         raise NotExist(f'User group "{context_group_object.name}" not found')
+    # TODO: Add attribute message=f"Sorry, you don't have permission to use this resource.
+    #       If you are a teacher of context_group, please contact TIM admin."
+    #       and remove corresponding error message generation from frontend.
     verify_teacher_access(d)
     new_badge = {
         "context_group": context_group,
@@ -291,6 +298,9 @@ def deactivate_badge(badge_id: int, context_group: str) -> Response:
     d = DocEntry.find_by_path(f"groups/{context_group}")  # TODO: Make this unambiguous.
     if not d:
         raise NotExist(f'User group with id "{context_group}" not found')
+    # TODO: Add attribute message=f"Sorry, you don't have permission to use this resource.
+    #       If you are a teacher of context_group, please contact TIM admin."
+    #       and remove corresponding error message generation from frontend.
     verify_teacher_access(d)
     new_badge = {
         "active": False,
@@ -314,7 +324,6 @@ def deactivate_badge(badge_id: int, context_group: str) -> Response:
     return json_response(new_badge, 200)
 
 
-# TODO: Not yet in use. If going to use this route, create tests for it and handle errors.
 @badges_blueprint.post("/reactivate_badge")
 def reactivate_badge(badge_id: int, context_group: str) -> Response:
     """
@@ -326,24 +335,30 @@ def reactivate_badge(badge_id: int, context_group: str) -> Response:
     d = DocEntry.find_by_path(f"groups/{context_group}")  # TODO: Make this unambiguous.
     if not d:
         raise NotExist(f'User group "{context_group}" not found')
+    # TODO: Add attribute message=f"Sorry, you don't have permission to use this resource.
+    #       If you are a teacher of context_group, please contact TIM admin."
+    #       and remove corresponding error message generation from frontend.
     verify_teacher_access(d)
-    badge = {
+    new_badge = {
         "active": True,
         "restored_by": get_current_user_object().id,
         "restored": datetime_tz.now(),
     }
-    Badge.query.filter_by(id=badge_id).update(badge)
+    old_badge = run_sql(select(Badge).filter_by(id=badge_id)).scalars().first()
+    if old_badge is None:
+        raise NotExist(f'Badge with id "{badge_id}" not found')
+    Badge.query.filter_by(id=badge_id).update(new_badge)
     db.session.commit()
     if current_app.config["BADGE_LOG_FILE"]:
         log_badge_event(
             {
                 "event": "restore_badge",
-                "timestamp": badge["restored"],
+                "timestamp": new_badge["restored"],
                 "id": badge_id,
-                "executor": badge["restored_by"],
+                "executor": new_badge["restored_by"],
             }
         )
-    return ok_response()
+    return json_response(new_badge, 200)
 
 
 # TODO: Check access rights and create tests for that.
@@ -355,6 +370,8 @@ def get_groups_badges(group_id: int, context_group: str) -> Response:
     :param context_group: Name of the context group
     :return: Badges in json response format
     """
+    if group_id == "undefined":
+        raise NotExist(f"User group not found")
     usergroup = UserGroup.get_by_id(group_id)
     if not usergroup:
         raise NotExist(f'User group with id "{group_id}" not found')
@@ -366,6 +383,9 @@ def get_groups_badges(group_id: int, context_group: str) -> Response:
         )  # TODO: Make this unambiguous.
         if not d:
             raise NotExist(f'User group "{context_group}" not found')
+        # TODO: Add attribute message=f"Sorry, you don't have permission to use this resource.
+        #       If you are a teacher of context_group, please contact TIM admin."
+        #       and remove corresponding error message generation from frontend.
         verify_teacher_access(d)
     groups_badges_given = (
         run_sql(
@@ -582,6 +602,9 @@ def give_badge(
     d = DocEntry.find_by_path(f"groups/{context_group}")  # TODO: Make this unambiguous.
     if not d:
         raise NotExist(f'User group "{context_group}" not found')
+    # TODO: Add attribute message=f"Sorry, you don't have permission to use this resource.
+    #       If you are a teacher of context_group, please contact TIM admin."
+    #       and remove corresponding error message generation from frontend.
     verify_teacher_access(d)
     badge_given = BadgeGiven(
         active=True,
@@ -622,6 +645,9 @@ def withdraw_badge(badge_given_id: int, context_group: str) -> Response:
     d = DocEntry.find_by_path(f"groups/{context_group}")  # TODO: Make this unambiguous.
     if not d:
         raise NotExist(f'User group "{context_group}" not found')
+    # TODO: Add attribute message=f"Sorry, you don't have permission to use this resource.
+    #       If you are a teacher of context_group, please contact TIM admin."
+    #       and remove corresponding error message generation from frontend.
     verify_teacher_access(d)
     badge_given = {
         "active": False,
@@ -663,6 +689,9 @@ def withdraw_all_badges(
     d = DocEntry.find_by_path(f"groups/{context_group}")  # TODO: Make this unambiguous.
     if not d:
         raise NotExist(f'User group "{context_group}" not found')
+    # TODO: Add attribute message=f"Sorry, you don't have permission to use this resource.
+    #       If you are a teacher of context_group, please contact TIM admin."
+    #       and remove corresponding error message generation from frontend.
     verify_teacher_access(d)
     badge_given = {
         "active": False,
@@ -687,8 +716,7 @@ def withdraw_all_badges(
     return json_response(badge_given, 200)
 
 
-# TODO: Not yet in use. If going to use this route, create tests for it and handle errors.
-@badges_blueprint.get("/undo_withdraw_badge")
+@badges_blueprint.post("/undo_withdraw_badge")
 def undo_withdraw_badge(badge_given_id: int, context_group: str) -> Response:
     """
     Undoes a badge withdrawal from a usergroup.
@@ -696,9 +724,15 @@ def undo_withdraw_badge(badge_given_id: int, context_group: str) -> Response:
     :param badge_given_id: ID of the badgegiven
     :return: ok response
     """
+    badge_given = BadgeGiven.get_by_id(badge_given_id)
+    if not badge_given:
+        raise NotExist(f'Given badge with id "{badge_given_id}" not found')
     d = DocEntry.find_by_path(f"groups/{context_group}")  # TODO: Make this unambiguous.
     if not d:
         raise NotExist(f'User group "{context_group}" not found')
+    # TODO: Add attribute message=f"Sorry, you don't have permission to use this resource.
+    #       If you are a teacher of context_group, please contact TIM admin."
+    #       and remove corresponding error message generation from frontend.
     verify_teacher_access(d)
     badge_given = {
         "active": True,
@@ -717,7 +751,7 @@ def undo_withdraw_badge(badge_given_id: int, context_group: str) -> Response:
                 "active": badge_given["active"],
             }
         )
-    return ok_response()
+    return json_response(badge_given, 200)
 
 
 # TODO: Create tests for this route.
@@ -766,6 +800,9 @@ def get_subgroups(group_name_prefix: str) -> Response:
     )  # TODO: Make this unambiguous.
     if not d:
         raise NotExist(f'User group "{group_name_prefix}" not found')
+    # TODO: Add attribute message=f"Sorry, you don't have permission to use this resource.
+    #       If you are a teacher of context_group, please contact TIM admin."
+    #       and remove corresponding error message generation from frontend.
     verify_teacher_access(d)
     subgroups = (
         run_sql(
@@ -867,5 +904,8 @@ def usergroups_members(usergroup_name: str) -> Response:
     )  # TODO: Make this unambiguous.
     if not d:
         raise NotExist(f'User group "{usergroup_name}" not found')
+    # TODO: Add attribute message=f"Sorry, you don't have permission to use this resource.
+    #       If you are a teacher of context_group, please contact TIM admin."
+    #       and remove corresponding error message generation from frontend.
     verify_teacher_access(d)
     return json_response(sorted(list(usergroup.users), key=attrgetter("real_name")))

--- a/timApp/static/scripts/tim/gamification/badge/badge-creator.component.ts
+++ b/timApp/static/scripts/tim/gamification/badge/badge-creator.component.ts
@@ -583,9 +583,9 @@ export class BadgeCreatorComponent implements OnInit {
     // Check if badge has been assigned to user_group
     async isBadgeAssigned() {
         const response = await toPromise(
-            this.http.get<any>(`/badge_given/${this.clickedBadge.id}`)
+            this.http.get<any>(`/badge_holders/${this.clickedBadge.id}`)
         );
-        if (response.result.length > 0) {
+        if (response.result[0].length > 0 || response.result[1].length > 0) {
             return true;
         } else {
             return false;

--- a/timApp/tests/server/test_badges.py
+++ b/timApp/tests/server/test_badges.py
@@ -287,11 +287,7 @@ class BadgeTestMain(TimRouteTest):
         result_grba_empty_1 = self.get(f"/groups_badges/{it_25_cats.id}/{it_25.name}")
         self.assertEqual([], result_grba_empty_1)
 
-        # check with badge_given-route is a badge given to some usergroup when no badges given
-        result_bg_empty = self.get("/badge_given/1")
-        self.assertEqual([], result_bg_empty)
-
-        # check with badge_holders-route is a badge given to some usergroup when no badges given
+        # check if a badge is given to some usergroup when no badges given
         result_bg_empty = self.get("/badge_holders/1")
         self.assertEqual([[], []], result_bg_empty)
 
@@ -431,43 +427,7 @@ class BadgeTestMain(TimRouteTest):
             result_grba_nonempty,
         )
 
-        # check with badge_given-route is a badge given to some usergroup
-        # after 3 badges given and one of them withdrawn
-        result_bg_nonempty = self.get("/badge_given/1")
-        self.assertEqual(
-            [
-                {
-                    "id": 1,
-                    "message": "Great work!",
-                    "badge_id": 1,
-                    "group_id": it_25_cats.id,
-                    "active": True,
-                    "given_by": self.test_user_1.id,
-                    "given": result_giba_1["given"],
-                    "withdrawn_by": None,
-                    "withdrawn": None,
-                    "undo_withdrawn_by": None,
-                    "undo_withdrawn": None,
-                },
-                {
-                    "id": 3,
-                    "message": "Great work again! Yeah!",
-                    "badge_id": 1,
-                    "group_id": it_25_cats.id,
-                    "active": True,
-                    "given_by": self.test_user_1.id,
-                    "given": result_giba_3["given"],
-                    "withdrawn_by": None,
-                    "withdrawn": None,
-                    "undo_withdrawn_by": None,
-                    "undo_withdrawn": None,
-                },
-            ],
-            result_bg_nonempty,
-        )
-
-        # check with badge_holders-route is a badge given to some usergroup
-        # after 3 badges given and one of them withdrawn
+        # check if a badge is given to some usergroup after 3 badges given and one of them withdrawn
         result_bg_nonempty = self.get("/badge_holders/1")
         self.assertEqual(
             [
@@ -968,14 +928,7 @@ class BadgeTestErroneousData(TimRouteTest):
             expect_content='User group "nonexistent_group" not found',
         )
 
-        # use badge_given-route with erroneous data
-        self.get(
-            "/badge_given/100",
-            expect_status=404,
-            expect_content='Badge with id "100" not found',
-        )
-
-        # use badge_holders-route with erroneous data
+        # check with erroneous data if a badge is given to someone
         self.get(
             "/badge_holders/100",
             expect_status=404,

--- a/timApp/tests/server/test_badges.py
+++ b/timApp/tests/server/test_badges.py
@@ -33,6 +33,10 @@ class BadgeTestMain(TimRouteTest):
         doc_it_26.block  # TODO: Why isn't the test working without this?
         self.login_test1()
 
+        # fetch all badges including inactive ones when no badges created
+        result_abii_empty = self.get(f"/all_badges_including_inactive")
+        self.assertEqual([], result_abii_empty)
+
         # fetch all badges when no badges created
         result_ab_empty = self.get(f"/all_badges")
         self.assertEqual([], result_ab_empty)
@@ -130,6 +134,30 @@ class BadgeTestMain(TimRouteTest):
             result_ab_nonempty,
         )
 
+        # fetch a specific badge
+        result_b = self.get(f"/badge/1")
+        self.assertEqual(
+            {
+                "active": True,
+                "color": "blue",
+                "context_group": it_25.id,
+                "created": result_cb_1["created"],
+                "created_by": 2,
+                "deleted": None,
+                "deleted_by": None,
+                "description": "Great coordination",
+                "id": 1,
+                "image": 1,
+                "modified": None,
+                "modified_by": None,
+                "restored": None,
+                "restored_by": None,
+                "shape": "hexagon",
+                "title": "Coordinator",
+            },
+            result_b,
+        )
+
         # modify a badge
         result_mb = self.post(
             "/modify_badge",
@@ -216,6 +244,50 @@ class BadgeTestMain(TimRouteTest):
                 "deleted_by": 2,
             },
             result_db,
+        )
+
+        # fetch all badges including inactive ones context after 2 badges created and the other one deleted
+        result_abii_nonempty = self.get(f"/all_badges_including_inactive")
+        self.assertEqual(
+            [
+                {
+                    "active": True,
+                    "color": "gold",
+                    "context_group": it_25.id,
+                    "created": result_cb_1["created"],
+                    "created_by": 2,
+                    "deleted": None,
+                    "deleted_by": None,
+                    "description": "Most valuable player",
+                    "id": 1,
+                    "image": 3,
+                    "modified": result_mb["modified"],
+                    "modified_by": 2,
+                    "restored": None,
+                    "restored_by": None,
+                    "shape": "hexagon",
+                    "title": "MVP",
+                },
+                {
+                    "active": False,
+                    "color": "red",
+                    "context_group": it_25.id,
+                    "created": result_cb_2["created"],
+                    "created_by": 2,
+                    "deleted": result_db["deleted"],
+                    "deleted_by": 2,
+                    "description": "Great communication",
+                    "id": 2,
+                    "image": 2,
+                    "modified": None,
+                    "modified_by": None,
+                    "restored": None,
+                    "restored_by": None,
+                    "shape": "round",
+                    "title": "Communicator",
+                },
+            ],
+            result_abii_nonempty,
         )
 
         # fetch all badges in context after 2 badges created and the other one deleted
@@ -336,8 +408,8 @@ class BadgeTestMain(TimRouteTest):
             },
         )
 
-        # withdraw a badge
-        result_wb = self.post(
+        # withdraw 2 badges
+        result_wb_1 = self.post(
             "/withdraw_badge",
             data={
                 "badge_given_id": 2,
@@ -348,12 +420,28 @@ class BadgeTestMain(TimRouteTest):
             {
                 "active": False,
                 "withdrawn_by": self.test_user_1.id,
-                "withdrawn": result_wb["withdrawn"],
+                "withdrawn": result_wb_1["withdrawn"],
             },
-            result_wb,
+            result_wb_1,
+        )
+        result_wb_2 = self.post(
+            "/withdraw_badge",
+            data={
+                "badge_given_id": 3,
+                "context_group": it_25.name,
+            },
         )
 
-        # fetch groups badges after 3 badges given and one of them withdrawn
+        # undo withdraw of a badge
+        result_uwb = self.post(
+            "/undo_withdraw_badge",
+            data={
+                "badge_given_id": 3,
+                "context_group": it_25.name,
+            },
+        )
+
+        # fetch groups badges after 3 badges given, two of them withdrawn and one of withdraws undid
         result_grba_nonempty = self.get(f"/groups_badges/{it_25_cats.id}/{it_25.name}")
         self.assertEqual(
             [
@@ -398,12 +486,12 @@ class BadgeTestMain(TimRouteTest):
                     "given_by": self.test_user_1.id,
                     "given_by_name": self.test_user_1.real_name,
                     "given": result_giba_3["given"],
-                    "withdrawn_by": None,
-                    "withdrawn_by_name": None,
-                    "withdrawn": None,
-                    "undo_withdrawn_by": None,
-                    "undo_withdrawn_by_name": None,
-                    "undo_withdrawn": None,
+                    "withdrawn_by": self.test_user_1.id,
+                    "withdrawn_by_name": self.test_user_1.real_name,
+                    "withdrawn": result_wb_2["withdrawn"],
+                    "undo_withdrawn_by": self.test_user_1.id,
+                    "undo_withdrawn_by_name": self.test_user_1.real_name,
+                    "undo_withdrawn": result_uwb["undo_withdrawn"],
                     "color": "gold",
                     "context_group": it_25.id,
                     "created": result_cb_1["created"],
@@ -586,6 +674,92 @@ class BadgeTestMain(TimRouteTest):
             expect_status=403,
         )
 
+        # restore a badge when user doesn't have teacher access to the context group
+        self.post(
+            f"/reactivate_badge",
+            data={
+                "badge_id": 2,
+                "context_group": it_25.name,
+            },
+            expect_content="Sorry, you don't have permission to use this resource.",
+            expect_status=403,
+        )
+
+        self.login_test1()
+
+        # restore a badge
+        result_rb = self.post(
+            f"/reactivate_badge",
+            data={
+                "badge_id": 2,
+                "context_group": it_25.name,
+            },
+            expect_status=200,
+        )
+
+        self.get(
+            f"/all_badges",
+            expect_content=[
+                {
+                    "active": True,
+                    "color": "gold",
+                    "context_group": it_25.id,
+                    "created": result_cb_1["created"],
+                    "created_by": 2,
+                    "deleted": None,
+                    "deleted_by": None,
+                    "description": "Most valuable player",
+                    "id": 1,
+                    "image": 3,
+                    "modified": result_mb["modified"],
+                    "modified_by": 2,
+                    "restored": None,
+                    "restored_by": None,
+                    "shape": "hexagon",
+                    "title": "MVP",
+                },
+                {
+                    "active": True,
+                    "color": "red",
+                    "context_group": it_25.id,
+                    "created": result_cb_2["created"],
+                    "created_by": 2,
+                    "deleted": result_db["deleted"],
+                    "deleted_by": 2,
+                    "description": "Great communication",
+                    "id": 2,
+                    "image": 2,
+                    "modified": None,
+                    "modified_by": None,
+                    "restored": result_rb["restored"],
+                    "restored_by": 2,
+                    "shape": "round",
+                    "title": "Communicator",
+                },
+                {
+                    "active": True,
+                    "color": "orange",
+                    "context_group": it_26.id,
+                    "created": result_cb_3["created"],
+                    "created_by": 2,
+                    "deleted": None,
+                    "deleted_by": None,
+                    "description": "Very fast",
+                    "id": 3,
+                    "image": 4,
+                    "modified": None,
+                    "modified_by": None,
+                    "restored": None,
+                    "restored_by": None,
+                    "shape": "rectangle",
+                    "title": "Quick",
+                },
+            ],
+            expect_status=200,
+        )
+
+        self.login_test3()
+
         # fetch groups badges when user doesn't have teacher access to the context group
         # and is not included in the context group
         self.get(
@@ -651,6 +825,17 @@ class BadgeTestMain(TimRouteTest):
             f"/withdraw_badge",
             data={
                 "badge_given_id": 4,
+                "context_group": it_25.name,
+            },
+            expect_content="Sorry, you don't have permission to use this resource.",
+            expect_status=403,
+        )
+
+        # undo a badge withdrawal when user doesn't have teacher access to the context group
+        self.post(
+            f"/undo_withdraw_badge",
+            data={
+                "badge_given_id": 3,
                 "context_group": it_25.name,
             },
             expect_content="Sorry, you don't have permission to use this resource.",
@@ -843,12 +1028,37 @@ class BadgeTestErroneousData(TimRouteTest):
             },
             expect_status=200,
         )
+        self.post(
+            f"/give_badge",
+            data={
+                "context_group": "it_27",
+                "group_id": self.test_user_1.get_personal_group().id,
+                "badge_id": 1,
+                "message": "Congratulations again!",
+            },
+            expect_status=200,
+        )
+        self.post(
+            f"/withdraw_badge",
+            data={
+                "badge_given_id": 2,
+                "context_group": "it_27",
+            },
+            expect_status=200,
+        )
 
         # fetch all badges in context with erroneous data
         self.get(
             f"/all_badges_in_context/nonexistent_group",
             expect_status=404,
             expect_content='User group "nonexistent_group" not found',
+        )
+
+        # fetch a specific badge with erroneous data
+        self.get(
+            f"/badge/100",
+            expect_status=404,
+            expect_content='Badge with id "100" not found',
         )
 
         # create a badge with erroneous data
@@ -900,11 +1110,11 @@ class BadgeTestErroneousData(TimRouteTest):
         self.post(
             f"/deactivate_badge",
             data={
-                "badge_id": 2,
+                "badge_id": 100,
                 "context_group": it_27.name,
             },
             expect_status=404,
-            expect_content='Badge with id "2" not found',
+            expect_content='Badge with id "100" not found',
         )
         self.post(
             f"/deactivate_badge",
@@ -914,6 +1124,26 @@ class BadgeTestErroneousData(TimRouteTest):
             },
             expect_status=404,
             expect_content='User group with id "100" not found',
+        )
+
+        # restore a badge with different erroneous data
+        self.post(
+            f"/reactivate_badge",
+            data={
+                "badge_id": 100,
+                "context_group": it_27.name,
+            },
+            expect_status=404,
+            expect_content='Badge with id "100" not found',
+        )
+        self.post(
+            f"/reactivate_badge",
+            data={
+                "badge_id": 1,
+                "context_group": "nonexistent_group",
+            },
+            expect_status=404,
+            expect_content='User group "nonexistent_group" not found',
         )
 
         # fetch groups badges with different erroneous data
@@ -984,6 +1214,26 @@ class BadgeTestErroneousData(TimRouteTest):
             f"/withdraw_badge",
             data={
                 "badge_given_id": 1,
+                "context_group": "nonexistent_group",
+            },
+            expect_status=404,
+            expect_content='User group "nonexistent_group" not found',
+        )
+
+        # undo a badge withdrawal with different erroneous data
+        self.post(
+            f"/undo_withdraw_badge",
+            data={
+                "badge_given_id": 100,
+                "context_group": it_27.name,
+            },
+            expect_status=404,
+            expect_content='Given badge with id "100" not found',
+        )
+        self.post(
+            f"/undo_withdraw_badge",
+            data={
+                "badge_given_id": 2,
                 "context_group": "nonexistent_group",
             },
             expect_status=404,


### PR DESCRIPTION
Remove badge_given-route and refactor frontend to use badge_holders-route instead of it. Add backend tests for routes that are not yet in use.