### PR TITLE
Badgeview rights

### DIFF
--- a/timApp/static/scripts/tim/plugin/group-dashboard/group-dashboard.component.scss
+++ b/timApp/static/scripts/tim/plugin/group-dashboard/group-dashboard.component.scss
@@ -28,10 +28,8 @@
     border-radius: 0.5em;
     box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
     position: relative;
-    z-index: 1;
-
+    z-index: auto;
 }
-
 
 .member-info {
     display: flex;
@@ -71,7 +69,8 @@
 .badge:hover {
     transform: scale(1);
     overflow: visible;
-    z-index: 10;
+    z-index: 999;
+    position: relative;
 }
 
 .dashboard-section {

--- a/timApp/static/scripts/tim/plugin/group-dashboard/group-dashboard.component.scss
+++ b/timApp/static/scripts/tim/plugin/group-dashboard/group-dashboard.component.scss
@@ -27,17 +27,11 @@
     border: 2px solid #0F4096;
     border-radius: 0.5em;
     box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
-    transition: transform 0.2s, box-shadow 0.2s; /* Member card's hovering effect */
     position: relative;
     z-index: 1;
 
 }
 
-.member-card:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 6px 15px rgba(0, 0, 0, 0.2);
-     z-index: 5;
-}
 
 .member-info {
     display: flex;

--- a/timApp/static/scripts/tim/plugin/group-dashboard/group-dashboard.component.ts
+++ b/timApp/static/scripts/tim/plugin/group-dashboard/group-dashboard.component.ts
@@ -70,17 +70,6 @@ import {Subscription} from "rxjs";
             </div>
         </div>
     </div>
-
-    <div class="dashboard-section">
-        <h2 class="section-title">Settings</h2>
-        <b>Change group name:</b>
-        <tim-group-name
-            *ngIf="group"
-            [group]="group"
-            (contextGroupChange)="onContextGroupChange($event)"
-            (groupNameChange)="onGroupNameChange($event)">
-        </tim-group-name>
-    </div>
                 </div>
 </ng-container>
 `,
@@ -108,7 +97,6 @@ export class GroupDashboardComponent implements OnInit {
     totalBadges: number = 0;
 
     //TODO: scrollbar ja skaalaus, kun badgeja on paljon
-    //TODO: real name jäsenten nimien tilalla
 
     ngOnInit() {
         if (this.group) {
@@ -117,6 +105,7 @@ export class GroupDashboardComponent implements OnInit {
     }
 
     async loadData() {
+        this.contextGroup = this.groupService.getContextGroup(this.group);
         await this.getGroupName();
         await this.fetchMembers();
         await this.fetchUserBadges();
@@ -192,19 +181,6 @@ export class GroupDashboardComponent implements OnInit {
         } catch (error) {
             console.error("Error fetching group mutual badges:", error);
         }
-    }
-
-    onContextGroupChange(context: string) {
-        this.contextGroup = context;
-    }
-
-    onGroupNameChange(newName: string) {
-        this.displayName = newName;
-        this.nameJustUpdated = true;
-
-        setTimeout(() => {
-            this.nameJustUpdated = false;
-        }, 1500);
     }
 
     private refreshTotalPoints() {

--- a/timApp/static/scripts/tim/plugin/group-dashboard/group-name.component.ts
+++ b/timApp/static/scripts/tim/plugin/group-dashboard/group-name.component.ts
@@ -26,12 +26,12 @@ import {ICurrentUser, IUser} from "tim/user/IUser";
                 <p>Pretty name: <b>{{prettyName}}</b></p>
             </div>
             <div class="changeName">
-                <button (click)="toggleInput()">Change group name</button>
-                <button (click)="toggleFullName()">
-    {{ showFullName ? "Show sub-group only" : "Show full group name" }}
-</button>
+    <button *ngIf="canEditName" (click)="toggleInput()">Change group name</button>
+    <button (click)="toggleFullName()">
+        {{ showFullName ? "Show sub-group only" : "Show full group name" }}
+    </button>
+</div>
 
-            </div>
             <div *ngIf="showInput">
                 <input [formControl]="newName" placeholder="Enter new group name"/>
                 <button (click)="saveName()" [disabled]="newName.invalid">Save</button>
@@ -54,6 +54,7 @@ export class GroupNameComponent implements OnInit {
     item: IFullDocument | IFolder | undefined;
     newName = new FormControl("", [Validators.required]);
     displayedName: string | null | undefined;
+    canEditName: boolean | undefined;
     showInput: boolean = false;
     showFullName = true;
     storedGroup: {name: string; id: number} | null = null;
@@ -91,6 +92,7 @@ export class GroupNameComponent implements OnInit {
                 ? this.groupName
                 : this.subGroup;
 
+            this.canEditName = fetchedGroup.isMember || fetchedGroup.isTeacher;
             this.parseParentGroup(this.groupName);
         }
     }

--- a/timApp/static/scripts/tim/plugin/group-dashboard/group.service.ts
+++ b/timApp/static/scripts/tim/plugin/group-dashboard/group.service.ts
@@ -123,4 +123,9 @@ export class GroupService {
             return result.result;
         }
     }
+
+    getContextGroup(fullName: string) {
+        const parts = fullName.split("-");
+        return parts[0];
+    }
 }

--- a/timApp/user/groups.py
+++ b/timApp/user/groups.py
@@ -521,6 +521,7 @@ def group_name(name: str) -> Response:
     current_user = get_current_user_object()
     is_member = check_group_member(current_user, group.id)
     is_teacher = False
+    is_admin = current_user.is_admin
     if not is_member:
         try:
             verify_teacher_access(block)
@@ -535,6 +536,7 @@ def group_name(name: str) -> Response:
             "description": pretty_name,
             "isMember": is_member,
             "isTeacher": is_teacher,
+            "isAdmin": is_admin,
         }
     )
 

--- a/timApp/user/groups.py
+++ b/timApp/user/groups.py
@@ -518,11 +518,23 @@ def group_name(name: str) -> Response:
     raise_group_not_found_if_none(name, group)
     block = group.admin_doc
     pretty_name = block.description
+    current_user = get_current_user_object()
+    is_member = check_group_member(current_user, group.id)
+    is_teacher = False
+    if not is_member:
+        try:
+            verify_teacher_access(block)
+            is_teacher = True
+        except AccessDenied:
+            is_teacher = False
+
     return json_response(
         {
             "id": group.id,
             "name": group.name,
             "description": pretty_name,
+            "isMember": is_member,
+            "isTeacher": is_teacher,
         }
     )
 


### PR DESCRIPTION
Edits group name fetching route to also check member, teacher & admin status.
Removes group name changer component and settings section from group dashboard component.
Removes name changer button visibility from non group members.
Allows regular group members to only see their own badges in addition to group's common badges
