### PR TITLE
change no badges message in badge creator

### DIFF
--- a/timApp/static/scripts/tim/gamification/badge/badge-creator.component.ts
+++ b/timApp/static/scripts/tim/gamification/badge/badge-creator.component.ts
@@ -62,7 +62,7 @@ import {scrollToElement} from "tim/util/utils";
                     
                     <div class="badge-view">
                       <ng-container *ngIf="all_badges.length == 0">
-                          <p class="no-badges-txt">This user/group does not have any badges yet.</p>
+                          <p class="no-badges-txt">This course does not have any badges yet.</p>
                       </ng-container>
                       <ng-container *ngIf="all_badges.length > 0">
                           <div class="badge-card" *ngFor="let badge of sortedBadges">


### PR DESCRIPTION
Changed the message that is displayed when a selected badgegroup context has not any badges yet to be more describing.